### PR TITLE
Remove legacy secret handling in simulate route

### DIFF
--- a/src/server/utils/crypto.ts
+++ b/src/server/utils/crypto.ts
@@ -41,19 +41,4 @@ export function ensureCryptoReady() {
   requireEnv('ENCRYPTION_KEY');
 }
 
-// Utilities for migration / fallback
-function keyFromSecret(secret: string): Buffer {
-  return crypto.scryptSync(secret, 'salt', 32);
-}
-
-export function decryptWithSecret(secret: string, encryptedText: string): string {
-  const algorithm = 'aes-256-cbc';
-  const key = keyFromSecret(secret);
-  const parts = encryptedText.split(':');
-  const iv = Buffer.from(parts.shift() as string, 'hex');
-  const encrypted = parts.join(':');
-  const decipher = crypto.createDecipheriv(algorithm, key, iv);
-  let decrypted = decipher.update(encrypted, 'hex', 'utf8');
-  decrypted += decipher.final('utf8');
-  return decrypted;
-}
+// Legacy migration helpers removed to enforce single encryption secret (ENCRYPTION_KEY)


### PR DESCRIPTION
# Remove legacy secret handling; enforce ENCRYPTION_KEY

## Summary
Simplifies and hardens encryption handling in the simulate API route by removing legacy secret paths and using only `ENCRYPTION_KEY`. Also standardizes logging and adds an early configuration check for clearer failures.

## Changes
- `src/app/api/simulate/route.ts`
  - Remove legacy `decryptWithSecret`/rotation logic; decrypt only via `ENCRYPTION_KEY`.
  - Add `ensureCryptoReady()` at the start of `POST`; return 500 if not configured.
  - Standardize logging to `getLogger()` (OpenAI errors, streaming, helpers).
  - Drop unused `id` from `userApiKey.findFirst(... select)`.
  - Clarify comment: “built-in scenario support” (avoid “legacy” wording).
- `src/server/utils/crypto.ts`
  - Remove unused migration helpers: `keyFromSecret`, `decryptWithSecret`.

## Rationale
- Security: A single, explicit encryption secret removes ambiguity and reduces risk.
- Maintainability: Less code surface, no in-request key rotation/migration logic.
- Observability: Consistent logger usage improves structured logs and correlation.

## Impact / Migration
- Breaking: User API keys encrypted with legacy secrets will not decrypt after this change.
- Action: Run a one-time migration to re-encrypt any legacy-encrypted keys with `ENCRYPTION_KEY` before deploy. Keep migration logic outside runtime.
- Ops: `ENCRYPTION_KEY` must be set; route returns 500 if missing (fail-fast).

## Validation
- Format: `npm run format:check` — pass
- Lint: `npm run lint` — pass
- Build: `npm run build` — pass

## Code Pointers
- Simulate route: `src/app/api/simulate/route.ts`
- Crypto utils: `src/server/utils/crypto.ts`
- Logger: `src/server/logging/logger.ts`

## Notes
- No UI changes.
- Happy to add a migration script or ops runbook if desired.
