### PR TITLE
Enforce Repository Pattern: Remove Prisma from Services, Add Scenarios Repository, and Update Docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ Guidance for working with this repository.
 - `docs/variables.md`: Variables system and resolution
 - `docs/testing.md`: Testing interface and simulation API
 - `docs/code-style.md`: Code style (Prettier + ESLint), editor, CI
+- `docs/architecture.md`: Layering, repository pattern, lint guardrails
 
 ## Commands
 
@@ -58,6 +59,7 @@ npm i
 - Pages: For dynamic routes on React 19, `params` may be a `Promise`. Use `React.use(params)` to unwrap when needed (see `src/app/scenarios/[id]/edit/page.tsx`).
 - API routes: The route handler context param is typed as `any` for broad Next.js compatibility.
 - Unified error shape via `src/server/http/responses.ts`.
+- Architecture guardrail: Services must not import Prisma or build Prisma queries. All DB access goes through `src/server/repos/*Repository.ts`. This is enforced by ESLint `no-restricted-imports` for `src/server/services/**` (blocking `@/lib/prisma` and `@prisma/client`).
 
 ## Core Flow
 
@@ -75,6 +77,8 @@ npm i
 - `src/lib/types.ts`: Core types (ChatMessage, Conversation, Scenario\*)
 - `src/lib/auth.ts`, `src/lib/auth-client.ts`, `src/lib/prisma.ts`
 - `middleware.ts`: Route protection
+- Repositories: `src/server/repos/*Repository.ts` (promptsRepository, variablesRepository, apiKeysRepository, scenariosRepository)
+- Services: `src/server/services/*Service.ts`
 
 ## Environment
 
@@ -83,6 +87,8 @@ DATABASE_URL=postgresql://...
 BETTER_AUTH_SECRET=...
 BETTER_AUTH_URL=http://localhost:3000
 ENCRYPTION_KEY=...   # Required for API key encryption
+
+Note: `.env` is git-ignored. Never commit real secrets. Example values live in `.env.example` only.
 ```
 
 ## Auth Notes

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ Compare prompt versions across real conversation scenarios and see the differenc
 - better-auth (Email+Password enabled by default)
 - OpenAI SDK
 
+## Architecture
+
+- Controllers (Next.js API routes) parse/validate input and call services.
+- Services orchestrate business logic and return DTOs — they do not access Prisma.
+- Repositories (`src/server/repos/*Repository.ts`) encapsulate all Prisma access and transactions.
+- Lint guardrail: services cannot import `@/lib/prisma` or `@prisma/client` (enforced via ESLint `no-restricted-imports`).
+
 ## Quick Start
 
 Prerequisites
@@ -132,6 +139,7 @@ ENCRYPTION_KEY="<paste_generated_value>"
 ## Database
 
 - ORM: Prisma. Schema lives at `prisma/schema.prisma`.
+- Unique constraints: Scenarios enforce unique `(userId, name)`; services map Prisma unique errors to a `DUPLICATE` error.
 - Commands
   - Generate client: `npx prisma generate`
   - Apply schema: `npx prisma db push`
@@ -153,6 +161,11 @@ Common setup: Vercel + Neon/Postgres
 - Set `DATABASE_URL`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, `ENCRYPTION_KEY` as project env vars (never commit them).
 - Run `prisma generate` during build (handled by `postinstall`).
 - Optional: run `prisma db push` on deploy to sync schema.
+
+## Secrets & Repository Hygiene
+
+- Do not commit secrets. `.env` is git-ignored; use `.env.example` to document required variables.
+- CI uses dummy environment values; no production secrets live in the repository.
 
 ## Contributing
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,8 +6,9 @@ This app follows a layered design:
   - Parse request, validate with Zod, call service, map to HTTP via `okJson/errorJson`.
 - Services: `src/server/services/*Service.ts`
   - Business logic, DTO mapping, cross-entity workflows, transactions.
-- Repos: `src/server/repos/*Repo.ts`
-  - Data access via Prisma; no business logic.
+- Repositories: `src/server/repos/*Repository.ts`
+  - Encapsulate all Prisma access and transactions; no business logic.
+  - Build Prisma filters from domain DTOs so services do not construct queries.
 
 ## Validation
 
@@ -34,12 +35,13 @@ This app follows a layered design:
 
 - UI/server share types via `src/lib/types.ts` and enums via `src/lib/constants/enums.ts`.
 - Services return DTOs (e.g., `PromptListItem`, `VariableListItem`, `ScenarioListItem`) — no Prisma entities leak to clients.
+- Repositories may also return DTOs where helpful (e.g., `scenariosRepository` returns `ScenarioListItem[]` and `ScenarioFull`).
 
 ## Files of Interest
 
-- Prompts: `promptsService` / `promptsRepo` used by `src/app/api/prompts/*`.
-- Variables: `variablesService` / `variablesRepo` used by `src/app/api/variables/*`.
-- Scenarios: `scenariosService` used by `src/app/api/scenarios/*` and duplicates/published routes.
+- Prompts: `promptsService` / `promptsRepository` used by `src/app/api/prompts/*`.
+- Variables: `variablesService` / `variablesRepository` used by `src/app/api/variables/*`.
+- Scenarios: `scenariosService` / `scenariosRepository` used by `src/app/api/scenarios/*` and duplicates/published routes.
 
 ## Conventions
 
@@ -53,6 +55,7 @@ This app follows a layered design:
 - Fonts are provided via CSS variables in `src/app/globals.css` (e.g., `--font-geist-sans`, `--font-geist-mono`) with system fallbacks.
 - We avoid network font fetches in CI and sandboxed environments. If you prefer Next.js `next/font`, consider self-hosting or gating by environment in a separate change.
 
-## Code Style
+## Code Style & Rules
 
 - Prettier + ESLint enforce formatting and common lint rules. See `docs/code-style.md`.
+- Services must not import Prisma directly — enforced by ESLint `no-restricted-imports` for `src/server/services/**` disallowing `@/lib/prisma` and `@prisma/client`.

--- a/docs/database.md
+++ b/docs/database.md
@@ -86,6 +86,7 @@ model Scenario {
   turns        ScenarioTurn[]
   expectations ScenarioExpectation[]
   versions     ScenarioVersion[]
+  @@unique([userId, name], name: "idx_scenario_user_name_unique")
 }
 
 model ScenarioTurn {
@@ -136,6 +137,11 @@ model UserApiKey {
 
 - Add appropriate indexes for frequent filters/sorts (userId, status, updatedAt). See `prisma/schema.prisma` for current indexes (Prompts, Scenarios, Variables, UserApiKey).
 - Prefer `_count` aggregates for list summaries (e.g., total turns) instead of loading full relations.
+
+## Uniqueness & Duplicates
+
+- Scenarios enforce a unique `(userId, name)` constraint to prevent duplicates.
+- Services translate Prisma unique violations (`P2002`) into a domain `DUPLICATE` error on create/duplicate.
 
 ## Commands
 

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -5,7 +5,7 @@ User-owned prompts with CRUD, tagging, and status; integrated with testing.
 ## Architecture
 
 - API routes: `src/app/api/prompts/*`
-- Service/Repo: `src/server/services/promptsService.ts`, `src/server/repos/promptsRepo.ts`
+- Service/Repository: `src/server/services/promptsService.ts`, `src/server/repos/promptsRepository.ts`
 - Validation: `src/server/validation/schemas.ts`
 
 ## Model (Prisma)

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -6,7 +6,7 @@ The Variables system allows users to create reusable key-value pairs that can be
 
 - Routes: `src/app/api/variables/*` are thin controllers.
 - Service: `src/server/services/variablesService.ts` handles create/update/delete/list and usage checks.
-- Repo: `src/server/repos/variablesRepo.ts` provides Prisma access and usage discovery.
+- Repository: `src/server/repos/variablesRepository.ts` provides Prisma access and usage discovery.
 - Validation via Zod in `src/server/validation/schemas.ts`.
 
 ## 📋 Table of Contents

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,6 +22,28 @@ const eslintConfig = [
       'react/no-unescaped-entities': 'off',
     },
   },
+  {
+    files: ['src/server/services/**/*.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: '@prisma/client',
+              message:
+                'Services must not import Prisma directly; use repositories for all DB access.',
+            },
+            {
+              name: '@/lib/prisma',
+              message:
+                'Services must not import the Prisma client; use repositories for all DB access.',
+            },
+          ],
+        },
+      ],
+    },
+  },
   // Disable ESLint rules that conflict with Prettier formatting
   prettier,
 ];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -100,6 +100,7 @@ model Scenario {
 
   @@map("scenario")
   @@index([userId, status, updatedAt], map: "idx_scenario_user_status_updated")
+  @@unique([userId, name], name: "idx_scenario_user_name_unique")
 }
 
 model ScenarioTurn {

--- a/src/app/api/scenarios/route.ts
+++ b/src/app/api/scenarios/route.ts
@@ -22,31 +22,6 @@ export async function GET(request: NextRequest) {
       tags: searchParams.get('tags')?.split(',').filter(Boolean) || undefined,
     });
 
-    const whereClause: Record<string, unknown> = {
-      userId: user.id,
-    };
-
-    if (filters.search) {
-      whereClause.OR = [
-        { name: { contains: filters.search, mode: 'insensitive' } },
-        { id: { contains: filters.search, mode: 'insensitive' } },
-        { tags: { hasSome: [filters.search] } },
-      ];
-    }
-
-    if (filters.locale) {
-      whereClause.locale = filters.locale;
-    }
-
-    if (filters.status) {
-      whereClause.status = filters.status;
-    }
-
-    if (filters.tags && filters.tags.length > 0) {
-      // Correct Prisma array predicate
-      whereClause.tags = { hasSome: filters.tags };
-    }
-
     const scenarioList: ScenarioListItem[] = await scenariosService.list(user.id, filters);
     return okJson(serializeBigInt(scenarioList));
   } catch (error) {

--- a/src/server/repos/apiKeysRepository.ts
+++ b/src/server/repos/apiKeysRepository.ts
@@ -1,6 +1,6 @@
 import { prisma } from '@/lib/prisma';
 
-export const apiKeysRepo = {
+export const apiKeysRepository = {
   async findActiveByUser(userId: string) {
     return prisma.userApiKey.findMany({
       where: { userId, isActive: true },

--- a/src/server/repos/scenariosRepository.ts
+++ b/src/server/repos/scenariosRepository.ts
@@ -1,0 +1,275 @@
+import { prisma } from '@/lib/prisma';
+import { Prisma } from '@prisma/client';
+import type {
+  CreateScenarioRequest,
+  ScenarioFilters,
+  UpdateScenarioRequest,
+  ScenarioListItem,
+  ScenarioFull,
+} from '@/lib/types';
+import type { ScenarioStatus, ScenarioTurnType, ExpectationType } from '@/lib/constants/enums';
+
+// Helper to coerce plain objects into Prisma JSON input types
+const toJson = (obj: unknown): Prisma.InputJsonValue => obj as Prisma.InputJsonValue;
+
+export const scenariosRepository = {
+  async findManyByUser(userId: string, filters: ScenarioFilters = {}): Promise<ScenarioListItem[]> {
+    const where: any = { userId };
+
+    if (filters.search) {
+      where.OR = [
+        { name: { contains: filters.search, mode: 'insensitive' } },
+        { id: { contains: filters.search, mode: 'insensitive' } },
+        { tags: { hasSome: [filters.search] } },
+      ];
+    }
+    if (filters.locale) where.locale = filters.locale;
+    if (filters.status) where.status = filters.status;
+    if (filters.tags?.length) where.tags = { hasSome: filters.tags };
+
+    const scenarios = await prisma.scenario.findMany({
+      where,
+      include: { _count: { select: { turns: true } } },
+      orderBy: { updatedAt: 'desc' },
+    });
+    return scenarios.map((s: any) => ({
+      id: s.id,
+      name: s.name,
+      description: s.description ?? undefined,
+      locale: s.locale,
+      tags: s.tags,
+      status: s.status as ScenarioStatus,
+      version: s.version,
+      userTurns: 0,
+      expectTurns: 0,
+      totalTurns: s._count?.turns ?? 0,
+      updatedAt: s.updatedAt,
+    }));
+  },
+
+  async findPublishedByUser(userId: string): Promise<ScenarioListItem[]> {
+    const scenarios = await prisma.scenario.findMany({
+      where: { userId, status: 'PUBLISHED' },
+      orderBy: { updatedAt: 'desc' },
+      select: {
+        id: true,
+        name: true,
+        description: true,
+        locale: true,
+        tags: true,
+        status: true,
+        version: true,
+        updatedAt: true,
+      },
+    });
+    return scenarios.map((s) => ({
+      id: s.id,
+      name: s.name,
+      description: s.description ?? undefined,
+      locale: s.locale,
+      tags: s.tags,
+      status: s.status as ScenarioStatus,
+      version: s.version,
+      userTurns: 0,
+      expectTurns: 0,
+      totalTurns: 0,
+      updatedAt: s.updatedAt,
+    }));
+  },
+
+  async getFullForUser(userId: string, id: string): Promise<ScenarioFull | null> {
+    const s = await prisma.scenario.findFirst({
+      where: { id, userId },
+      include: {
+        turns: {
+          include: { expectations: true },
+          orderBy: { orderIndex: 'asc' },
+        },
+      },
+    });
+    if (!s) return null;
+    return {
+      id: s.id,
+      userId: s.userId,
+      name: s.name,
+      description: s.description ?? undefined,
+      locale: s.locale,
+      seed: s.seed ?? undefined,
+      maxTurns: s.maxTurns ?? undefined,
+      status: s.status as ScenarioStatus,
+      version: s.version,
+      tags: s.tags,
+      createdAt: s.createdAt,
+      updatedAt: s.updatedAt,
+      turns: s.turns.map((t) => ({
+        id: t.id,
+        orderIndex: t.orderIndex,
+        turnType: t.turnType as ScenarioTurnType,
+        userText: t.userText ?? undefined,
+        expectations: t.expectations.map((e) => ({
+          id: e.id,
+          expectationKey: e.expectationKey,
+          expectationType: e.expectationType as ExpectationType,
+          argsJson: (e.argsJson as any) ?? {},
+          weight: e.weight ?? undefined,
+        })),
+      })),
+    };
+  },
+
+  async findByNameForUser(name: string, userId: string) {
+    return prisma.scenario.findFirst({ where: { name, userId } });
+  },
+
+  async createWithTurns(userId: string, dto: CreateScenarioRequest) {
+    return prisma.$transaction(async (tx) => {
+      const scenario = await tx.scenario.create({
+        data: {
+          userId,
+          name: dto.name,
+          description: dto.description,
+          locale: dto.locale || 'en',
+          status: dto.status || 'DRAFT',
+          tags: dto.tags || [],
+        },
+      });
+
+      if (dto.turns?.length) {
+        for (const turn of dto.turns) {
+          const createdTurn = await tx.scenarioTurn.create({
+            data: {
+              scenarioId: scenario.id,
+              orderIndex: turn.orderIndex ?? 0,
+              turnType: turn.turnType,
+              userText: turn.userText,
+            },
+          });
+          if (turn.expectations?.length) {
+            await tx.scenarioExpectation.createMany({
+              data: turn.expectations.map((exp) => ({
+                scenarioId: scenario.id,
+                turnId: createdTurn.id,
+                expectationKey: exp.expectationKey,
+                expectationType: exp.expectationType,
+                argsJson: toJson(exp.argsJson ?? {}),
+                weight: exp.weight,
+              })),
+            });
+          }
+        }
+      }
+
+      return scenario;
+    });
+  },
+
+  async replaceWithTurns(userId: string, id: string, dto: UpdateScenarioRequest) {
+    return prisma.$transaction(async (tx) => {
+      // Ensure the scenario belongs to the user
+      const existing = await tx.scenario.findFirst({ where: { id, userId } });
+      if (!existing) return null;
+
+      await tx.scenarioTurn.deleteMany({ where: { scenarioId: id } });
+      await tx.scenario.update({
+        where: { id },
+        data: {
+          name: dto.name,
+          description: dto.description,
+          locale: dto.locale || 'en',
+          status: dto.status,
+          tags: dto.tags || [],
+          version: { increment: 1 },
+        },
+      });
+
+      if (dto.turns?.length) {
+        for (const turn of dto.turns) {
+          const createdTurn = await tx.scenarioTurn.create({
+            data: {
+              scenarioId: id,
+              orderIndex: turn.orderIndex ?? 0,
+              turnType: turn.turnType,
+              userText: turn.userText,
+            },
+          });
+          if (turn.expectations?.length) {
+            await tx.scenarioExpectation.createMany({
+              data: turn.expectations.map((exp) => ({
+                scenarioId: id,
+                turnId: createdTurn.id,
+                expectationKey: exp.expectationKey,
+                expectationType: exp.expectationType,
+                argsJson: toJson(exp.argsJson ?? {}),
+                weight: exp.weight,
+              })),
+            });
+          }
+        }
+      }
+
+      return true;
+    });
+  },
+
+  async deleteForUser(userId: string, id: string) {
+    const existing = await prisma.scenario.findFirst({ where: { id, userId } });
+    if (!existing) return false;
+    await prisma.scenario.delete({ where: { id } });
+    return true;
+  },
+
+  async duplicate(userId: string, id: string) {
+    const existing = await prisma.scenario.findFirst({
+      where: { id, userId },
+      include: {
+        turns: { include: { expectations: true }, orderBy: { orderIndex: 'asc' } },
+      },
+    });
+    if (!existing) return null;
+
+    let name = `${existing.name} (Copy)`;
+    let counter = 1;
+    while (await prisma.scenario.findFirst({ where: { userId, name } })) {
+      counter++;
+      name = `${existing.name} (Copy ${counter})`;
+    }
+
+    const created = await prisma.$transaction(async (tx) => {
+      const scenario = await tx.scenario.create({
+        data: {
+          userId,
+          name,
+          description: existing.description ?? undefined,
+          locale: existing.locale,
+          status: 'DRAFT',
+          tags: existing.tags,
+        },
+      });
+      for (const turn of existing.turns) {
+        const createdTurn = await tx.scenarioTurn.create({
+          data: {
+            scenarioId: scenario.id,
+            orderIndex: turn.orderIndex,
+            turnType: turn.turnType,
+            userText: turn.userText ?? undefined,
+          },
+        });
+        if (turn.expectations.length) {
+          await tx.scenarioExpectation.createMany({
+            data: turn.expectations.map((exp) => ({
+              scenarioId: scenario.id,
+              turnId: createdTurn.id,
+              expectationKey: exp.expectationKey,
+              expectationType: exp.expectationType,
+              argsJson: toJson(exp.argsJson ?? {}),
+              weight: exp.weight ?? undefined,
+            })),
+          });
+        }
+      }
+      return scenario;
+    });
+
+    return created;
+  },
+};

--- a/src/server/repos/variablesRepository.ts
+++ b/src/server/repos/variablesRepository.ts
@@ -1,10 +1,19 @@
 import { prisma } from '@/lib/prisma';
 import { Prisma } from '@prisma/client';
+import type { VariableFilters } from '@/lib/types';
 
-export const variablesRepo = {
-  async findManyByUser(userId: string, where: Prisma.VariableWhereInput = {}) {
+export const variablesRepository = {
+  async findManyByUser(userId: string, filters: VariableFilters = {}) {
+    const where: Prisma.VariableWhereInput = { userId } as any;
+    if (filters.search) {
+      (where as any).OR = [
+        { key: { contains: filters.search, mode: 'insensitive' } },
+        { value: { contains: filters.search, mode: 'insensitive' } },
+        { description: { contains: filters.search, mode: 'insensitive' } },
+      ];
+    }
     return prisma.variable.findMany({
-      where: { userId, ...where },
+      where,
       orderBy: { updatedAt: 'desc' },
     });
   },

--- a/src/server/services/apiKeysService.ts
+++ b/src/server/services/apiKeysService.ts
@@ -1,17 +1,17 @@
-import { apiKeysRepo } from '@/server/repos/apiKeysRepo';
+import { apiKeysRepository } from '@/server/repos/apiKeysRepository';
 
 export const apiKeysService = {
   async listActive(userId: string) {
-    return apiKeysRepo.findActiveByUser(userId);
+    return apiKeysRepository.findActiveByUser(userId);
   },
   async upsertActive(userId: string, provider: string, keyName: string, encryptedKey: string) {
-    const existing = await apiKeysRepo.findAnyByUserAndProvider(userId, provider);
+    const existing = await apiKeysRepository.findAnyByUserAndProvider(userId, provider);
     if (existing) {
-      return apiKeysRepo.update(existing.id, { keyName, encryptedKey, isActive: true });
+      return apiKeysRepository.update(existing.id, { keyName, encryptedKey, isActive: true });
     }
-    return apiKeysRepo.create(userId, provider, keyName, encryptedKey);
+    return apiKeysRepository.create(userId, provider, keyName, encryptedKey);
   },
   async deactivate(userId: string, provider: string) {
-    await apiKeysRepo.deactivateByProvider(userId, provider);
+    await apiKeysRepository.deactivateByProvider(userId, provider);
   },
 };

--- a/src/server/services/scenariosService.ts
+++ b/src/server/services/scenariosService.ts
@@ -1,257 +1,86 @@
-import { prisma } from '@/lib/prisma';
+import { scenariosRepository } from '@/server/repos/scenariosRepository';
 import {
   ScenarioFiltersSchema,
   CreateScenarioSchema,
   UpdateScenarioSchema,
 } from '@/server/validation/schemas';
-import { ScenarioFilters, ScenarioListItem, ScenarioStatus } from '@/lib/types';
-import { Prisma } from '@prisma/client';
+import { ScenarioFilters } from '@/lib/types';
 
 export const scenariosService = {
   async list(userId: string, filters: ScenarioFilters) {
     const parsed = ScenarioFiltersSchema.parse(filters);
-    const where: any = { userId };
-    if (parsed.search) {
-      where.OR = [
-        { name: { contains: parsed.search, mode: 'insensitive' } },
-        { id: { contains: parsed.search, mode: 'insensitive' } },
-        { tags: { hasSome: [parsed.search] } },
-      ];
-    }
-    if (parsed.locale) where.locale = parsed.locale;
-    if (parsed.status) where.status = parsed.status as ScenarioStatus;
-    if (parsed.tags?.length) where.tags = { hasSome: parsed.tags };
-
-    const scenarios = await prisma.scenario.findMany({
-      where,
-      include: { _count: { select: { turns: true } } },
-      orderBy: { updatedAt: 'desc' },
-    });
-
-    const list: ScenarioListItem[] = scenarios.map((s) => ({
-      id: s.id,
-      name: s.name,
-      description: s.description ?? undefined,
-      locale: s.locale,
-      tags: s.tags,
-      status: s.status as ScenarioStatus,
-      version: s.version,
-      userTurns: 0,
-      expectTurns: 0,
-      totalTurns: (s as any)._count?.turns ?? 0,
-      updatedAt: s.updatedAt,
-    }));
-    return list;
+    return scenariosRepository.findManyByUser(userId, parsed);
   },
 
   async listPublished(userId: string) {
-    const scenarios = await prisma.scenario.findMany({
-      where: { userId, status: 'PUBLISHED' },
-      orderBy: { updatedAt: 'desc' },
-      select: {
-        id: true,
-        name: true,
-        description: true,
-        locale: true,
-        tags: true,
-        status: true,
-        version: true,
-        updatedAt: true,
-      },
-    });
-    const list: ScenarioListItem[] = scenarios.map((s) => ({
-      id: s.id,
-      name: s.name,
-      description: s.description ?? undefined,
-      locale: s.locale,
-      tags: s.tags,
-      status: s.status as ScenarioStatus,
-      version: s.version,
-      userTurns: 0,
-      expectTurns: 0,
-      totalTurns: 0,
-      updatedAt: s.updatedAt,
-    }));
-    return list;
+    return scenariosRepository.findPublishedByUser(userId);
   },
 
   async getFull(userId: string, id: string) {
-    return prisma.scenario.findFirst({
-      where: { id, userId },
-      include: {
-        turns: {
-          include: { expectations: true },
-          orderBy: { orderIndex: 'asc' },
-        },
-      },
-    });
+    return scenariosRepository.getFullForUser(userId, id);
   },
 
   async create(userId: string, body: unknown) {
     const parsed = CreateScenarioSchema.parse(body);
-    const dupe = await prisma.scenario.findFirst({ where: { name: parsed.name, userId } });
+    const dupe = await scenariosRepository.findByNameForUser(parsed.name, userId);
     if (dupe)
       return {
         error: true as const,
         code: 'DUPLICATE',
         message: 'Scenario with this name already exists',
       };
-
-    const created = await prisma.$transaction(async (tx) => {
-      const scenario = await tx.scenario.create({
-        data: {
-          userId,
-          name: parsed.name,
-          description: parsed.description,
-          locale: parsed.locale || 'en',
-          status: parsed.status || 'DRAFT',
-          tags: parsed.tags || [],
-        },
-      });
-
-      if (parsed.turns?.length) {
-        for (const turn of parsed.turns) {
-          const createdTurn = await tx.scenarioTurn.create({
-            data: {
-              scenarioId: scenario.id,
-              orderIndex: turn.orderIndex ?? 0,
-              turnType: turn.turnType,
-              userText: turn.userText,
-            },
-          });
-          if (turn.expectations?.length) {
-            await tx.scenarioExpectation.createMany({
-              data: turn.expectations.map((exp) => ({
-                scenarioId: scenario.id,
-                turnId: createdTurn.id,
-                expectationKey: exp.expectationKey,
-                expectationType: exp.expectationType,
-                argsJson: exp.argsJson as Prisma.JsonObject,
-                weight: exp.weight,
-              })),
-            });
-          }
-        }
+    try {
+      const created = await scenariosRepository.createWithTurns(userId, parsed);
+      const full = await scenariosRepository.getFullForUser(userId, created.id);
+      return { error: false as const, data: full };
+    } catch (err: any) {
+      if (err && typeof err === 'object' && (err as any).code === 'P2002') {
+        return {
+          error: true as const,
+          code: 'DUPLICATE',
+          message: 'Scenario with this name already exists',
+        };
       }
-
-      return scenario;
-    });
-
-    const full = await this.getFull(userId, created.id);
-    return { error: false as const, data: full };
+      throw err;
+    }
   },
 
   async update(userId: string, id: string, body: unknown) {
     const parsed = UpdateScenarioSchema.parse(body);
-    const existing = await prisma.scenario.findFirst({ where: { id, userId } });
+    const existing = await scenariosRepository.getFullForUser(userId, id);
     if (!existing)
       return { error: true as const, code: 'NOT_FOUND', message: 'Scenario not found' };
 
-    await prisma.$transaction(async (tx) => {
-      await tx.scenarioTurn.deleteMany({ where: { scenarioId: id } });
-      await tx.scenario.update({
-        where: { id },
-        data: {
-          name: parsed.name,
-          description: parsed.description,
-          locale: parsed.locale || 'en',
-          status: parsed.status,
-          tags: parsed.tags || [],
-          version: { increment: 1 },
-        },
-      });
-      if (parsed.turns?.length) {
-        for (const turn of parsed.turns) {
-          const createdTurn = await tx.scenarioTurn.create({
-            data: {
-              scenarioId: id,
-              orderIndex: turn.orderIndex ?? 0,
-              turnType: turn.turnType,
-              userText: turn.userText,
-            },
-          });
-          if (turn.expectations?.length) {
-            await tx.scenarioExpectation.createMany({
-              data: turn.expectations.map((exp) => ({
-                scenarioId: id,
-                turnId: createdTurn.id,
-                expectationKey: exp.expectationKey,
-                expectationType: exp.expectationType,
-                argsJson: exp.argsJson as Prisma.JsonObject,
-                weight: exp.weight,
-              })),
-            });
-          }
-        }
-      }
-    });
+    const replaced = await scenariosRepository.replaceWithTurns(userId, id, parsed);
+    if (!replaced)
+      return { error: true as const, code: 'NOT_FOUND', message: 'Scenario not found' };
 
-    const full = await this.getFull(userId, id);
+    const full = await scenariosRepository.getFullForUser(userId, id);
     return { error: false as const, data: full };
   },
 
   async remove(userId: string, id: string) {
-    const existing = await prisma.scenario.findFirst({ where: { id, userId } });
-    if (!existing)
-      return { error: true as const, code: 'NOT_FOUND', message: 'Scenario not found' };
-    await prisma.scenario.delete({ where: { id } });
+    const ok = await scenariosRepository.deleteForUser(userId, id);
+    if (!ok) return { error: true as const, code: 'NOT_FOUND', message: 'Scenario not found' };
     return { error: false as const };
   },
 
   async duplicate(userId: string, id: string) {
-    const existing = await prisma.scenario.findFirst({
-      where: { id, userId },
-      include: {
-        turns: { include: { expectations: true }, orderBy: { orderIndex: 'asc' } },
-      },
-    });
-    if (!existing)
-      return { error: true as const, code: 'NOT_FOUND', message: 'Scenario not found' };
-
-    let name = `${existing.name} (Copy)`;
-    let counter = 1;
-    while (await prisma.scenario.findFirst({ where: { userId, name } })) {
-      counter++;
-      name = `${existing.name} (Copy ${counter})`;
-    }
-
-    const created = await prisma.$transaction(async (tx) => {
-      const scenario = await tx.scenario.create({
-        data: {
-          userId,
-          name,
-          description: existing.description,
-          locale: existing.locale,
-          status: 'DRAFT',
-          tags: existing.tags,
-        },
-      });
-      for (const turn of existing.turns) {
-        const createdTurn = await tx.scenarioTurn.create({
-          data: {
-            scenarioId: scenario.id,
-            orderIndex: turn.orderIndex,
-            turnType: turn.turnType,
-            userText: turn.userText,
-          },
-        });
-        if (turn.expectations.length) {
-          await tx.scenarioExpectation.createMany({
-            data: turn.expectations.map((exp) => ({
-              scenarioId: scenario.id,
-              turnId: createdTurn.id,
-              expectationKey: exp.expectationKey,
-              expectationType: exp.expectationType,
-              argsJson: exp.argsJson as Prisma.JsonObject,
-              weight: exp.weight,
-            })),
-          });
-        }
+    try {
+      const created = await scenariosRepository.duplicate(userId, id);
+      if (!created)
+        return { error: true as const, code: 'NOT_FOUND', message: 'Scenario not found' };
+      const full = await scenariosRepository.getFullForUser(userId, created.id);
+      return { error: false as const, data: full };
+    } catch (err: any) {
+      if (err && typeof err === 'object' && (err as any).code === 'P2002') {
+        return {
+          error: true as const,
+          code: 'DUPLICATE',
+          message: 'A scenario with the generated name already exists',
+        };
       }
-      return scenario;
-    });
-
-    const full = await this.getFull(userId, created.id);
-    return { error: false as const, data: full };
+      throw err;
+    }
   },
 };

--- a/src/server/services/variablesService.ts
+++ b/src/server/services/variablesService.ts
@@ -1,4 +1,4 @@
-import { variablesRepo } from '@/server/repos/variablesRepo';
+import { variablesRepository } from '@/server/repos/variablesRepository';
 import {
   VariableFiltersSchema,
   CreateVariableSchema,
@@ -9,15 +9,7 @@ import { VariableFilters, VariableListItem } from '@/lib/types';
 export const variablesService = {
   async list(userId: string, filters: VariableFilters) {
     const parsed = VariableFiltersSchema.parse(filters);
-    const where: any = {};
-    if (parsed.search) {
-      where.OR = [
-        { key: { contains: parsed.search, mode: 'insensitive' } },
-        { value: { contains: parsed.search, mode: 'insensitive' } },
-        { description: { contains: parsed.search, mode: 'insensitive' } },
-      ];
-    }
-    const vars = await variablesRepo.findManyByUser(userId, where);
+    const vars = await variablesRepository.findManyByUser(userId, parsed);
     const list: VariableListItem[] = vars.map((v) => ({
       id: v.id,
       key: v.key,
@@ -29,19 +21,19 @@ export const variablesService = {
   },
 
   async get(userId: string, id: string) {
-    return variablesRepo.findByIdForUser(id, userId);
+    return variablesRepository.findByIdForUser(id, userId);
   },
 
   async create(userId: string, body: unknown) {
     const parsed = CreateVariableSchema.parse(body);
-    const dupe = await variablesRepo.findByKeyForUser(parsed.key, userId);
+    const dupe = await variablesRepository.findByKeyForUser(parsed.key, userId);
     if (dupe)
       return {
         error: true as const,
         code: 'DUPLICATE',
         message: 'Variable with this key already exists',
       };
-    const created = await variablesRepo.create({
+    const created = await variablesRepository.create({
       user: { connect: { id: userId } },
       key: parsed.key,
       value: parsed.value,
@@ -52,11 +44,11 @@ export const variablesService = {
 
   async update(userId: string, id: string, body: unknown) {
     const parsed = UpdateVariableSchema.parse(body);
-    const existing = await variablesRepo.findByIdForUser(id, userId);
+    const existing = await variablesRepository.findByIdForUser(id, userId);
     if (!existing)
       return { error: true as const, code: 'NOT_FOUND', message: 'Variable not found' };
     if (parsed.key !== existing.key) {
-      const dupe = await variablesRepo.findByKeyForUser(parsed.key, userId);
+      const dupe = await variablesRepository.findByKeyForUser(parsed.key, userId);
       if (dupe)
         return {
           error: true as const,
@@ -64,7 +56,7 @@ export const variablesService = {
           message: 'Variable with this key already exists',
         };
     }
-    const updated = await variablesRepo.update(id, {
+    const updated = await variablesRepository.update(id, {
       key: parsed.key,
       value: parsed.value,
       description: parsed.description,
@@ -73,10 +65,10 @@ export const variablesService = {
   },
 
   async remove(userId: string, id: string) {
-    const existing = await variablesRepo.findByIdForUser(id, userId);
+    const existing = await variablesRepository.findByIdForUser(id, userId);
     if (!existing)
       return { error: true as const, code: 'NOT_FOUND', message: 'Variable not found' };
-    const usage = await variablesRepo.usage(existing.key, userId);
+    const usage = await variablesRepository.usage(existing.key, userId);
     if (usage.prompts.length > 0 || usage.scenarios.length > 0) {
       return {
         error: true as const,
@@ -85,7 +77,7 @@ export const variablesService = {
         details: usage,
       };
     }
-    await variablesRepo.delete(id);
+    await variablesRepository.delete(id);
     return { error: false as const };
   },
 };


### PR DESCRIPTION
## Summary

This PR completes a repo-wide refactor to enforce a clean architecture:
- All database access now goes through repositories in `src/server/repos/**`.
- Services no longer import or construct Prisma queries; they orchestrate business logic only.
- A new `scenariosRepository` centralizes transactional scenario operations and returns domain DTOs.
- Unified naming for repositories: `*Repository.ts`.
- Lint guardrails block Prisma usage in services.
- Docs updated to reflect the pattern and DB uniqueness.

## Key Changes

- Repositories
  - Added `src/server/repos/scenariosRepository.ts` with transactional methods:
    - `findManyByUser`, `findPublishedByUser` → return `ScenarioListItem[]` (with `totalTurns`).
    - `getFullForUser` → returns `ScenarioFull`.
    - `createWithTurns`, `replaceWithTurns`, `duplicate`, `deleteForUser`.
  - Moved filter-building into repos for Prompts and Variables.
  - Renamed `*Repo.ts` → `*Repository.ts` and updated exports/imports.

- Services
  - `scenariosService` now delegates all DB work to `scenariosRepository`.
  - Duplicate handling (Prisma `P2002`) in `create` and `duplicate` to return `DUPLICATE` domain errors.
  - `promptsService` and `variablesService` simplified to pass domain filters to repos.

- Lint Guardrails
  - ESLint `no-restricted-imports` for `src/server/services/**` disallows `@/lib/prisma`, `@prisma/client`.

- Database
  - Added unique constraint on `Scenario (userId, name)`.
  - Applied via `prisma db push`.

- Controllers
  - Removed unused `whereClause` from scenarios list route; services/repos own the filters.

- Docs
  - Updated `docs/architecture.md`, `docs/database.md`, `docs/prompts.md`, `docs/variables.md`.
  - Updated `README.md` (Architecture, DB uniqueness, secrets hygiene).
  - Updated `CLAUDE.md` with repository pattern and lint rule.

## Rationale

- Keeps a strict separation of concerns:
  - Controllers: HTTP + parsing + auth
  - Services: business orchestration, validation, DTOs
  - Repositories: Prisma access + transactions + query construction
- Enables future ORM swapping and easier testing.

## Testing & Verification

- TypeScript: `tsc --noEmit` passes
- ESLint: passes, including new restriction rule
- Prettier: formatted repo (`npm run format`)
- Next.js build: successful locally
- Prisma: client generated and DB schema pushed; unique constraint applied

## Backwards Compatibility

- API contracts preserved. Only internal structure changed.
- Repos return DTOs where convenient; service return shapes unchanged.

## Follow-ups (Optional)

- Consider extracting mapping helpers in `scenariosRepository` for reuse/readability.
- Add a short test suite for repository transactions and duplicate handling.
- Consider returning DTOs from prompts/variables repos to further reduce mapping in services.

## Checklist
- [x] No direct Prisma usage in services
- [x] All DB access via repositories
- [x] Unified `*Repository.ts` naming
- [x] ESLint rule to enforce boundary
- [x] Docs updated
- [x] Build and type checks pass
- [x] No secrets or sensitive data committed
